### PR TITLE
Added return type to prevent compilation errors with -Werror=return-type

### DIFF
--- a/src/Wnck.cpp
+++ b/src/Wnck.cpp
@@ -261,6 +261,7 @@ namespace Wnck
 
 			return menu;
 		}
+		return FALSE;
 	}
 
 	void switchToLastWindow(guint32 timestamp)


### PR DESCRIPTION
Fixes issue #57. When -Werror=return-type the compiler thinks not having a return type is an error. Simply adding a string to prevent that works.