### PR TITLE
Ubuntu 18.04 build compatibility patch, closes #52, closes #41

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -10,5 +10,5 @@ EOF
   exit 1
 }
 
-XDT_AUTOGEN_REQUIRED_VERSION="4.14.0" \
+XDT_AUTOGEN_REQUIRED_VERSION="4.12.0" \
 exec xdt-autogen $@

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -55,6 +55,7 @@ AC_HEADER_STDC()
 dnl ***********************************
 dnl *** Check for required packages ***
 dnl ***********************************
+m4_define([xfce_build_version], [4.14.0])
 XDT_CHECK_LIBX11_REQUIRE()
 XDT_CHECK_PACKAGE([GIO], [gio-2.0], [2.42.0])
 XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [2.42.0])
@@ -62,9 +63,9 @@ XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [3.24.0])
 XDT_CHECK_PACKAGE([CAIRO], [cairo], [1.16.0])
 XDT_CHECK_PACKAGE([WNCK], [libwnck-3.0], [3.30.0])
 XDT_CHECK_PACKAGE([X11], [x11], [1.6])
-XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2], [4.14.0])
-XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0], [4.14.0])
-XDT_CHECK_PACKAGE([LIBXFCE4PANEL], [libxfce4panel-2.0], [4.14.0])
+XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2], [xfce_build_version()])
+XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0], [xfce_build_version()])
+XDT_CHECK_PACKAGE([LIBXFCE4PANEL], [libxfce4panel-2.0], [xfce_build_version()])
 
 dnl ******************************
 dnl *** Check for i18n support ***

--- a/contrib/patches/0001-ubuntu-18.04-build-compatibility.patch
+++ b/contrib/patches/0001-ubuntu-18.04-build-compatibility.patch
@@ -1,0 +1,51 @@
+From bd421924ad6aa1b1fed1900253b3dbd670155c54 Mon Sep 17 00:00:00 2001
+From: Gregor Santner <gsantner@mailbox.org>
+Date: Wed, 23 Dec 2020 10:51:01 +0100
+Subject: [PATCH] Ubuntu 18.04 build compatibility patch
+
+* See PR https://github.com/nsz32/docklike-plugin/pull/66
+* Closes issues 52, closes 41
+* sudo apt install xfce4-dev-tools libxfce4panel-2.0  libxfce4ui-2-dev libwnck-3-dev libwnck-3.0
+---
+ configure.ac.in | 8 ++++----
+ src/Helpers.cpp | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/configure.ac.in b/configure.ac.in
+index 640bff3..ebfcdcc 100644
+--- a/configure.ac.in
++++ b/configure.ac.in
+@@ -55,13 +55,13 @@ AC_HEADER_STDC()
+ dnl ***********************************
+ dnl *** Check for required packages ***
+ dnl ***********************************
+-m4_define([xfce_build_version], [4.14.0])
++m4_define([xfce_build_version], [4.12.0])
+ XDT_CHECK_LIBX11_REQUIRE()
+ XDT_CHECK_PACKAGE([GIO], [gio-2.0], [2.42.0])
+ XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [2.42.0])
+-XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [3.24.0])
+-XDT_CHECK_PACKAGE([CAIRO], [cairo], [1.16.0])
+-XDT_CHECK_PACKAGE([WNCK], [libwnck-3.0], [3.30.0])
++XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [3.22.0])
++XDT_CHECK_PACKAGE([CAIRO], [cairo], [1.15.0])
++XDT_CHECK_PACKAGE([WNCK], [libwnck-3.0], [3.24.0])
+ XDT_CHECK_PACKAGE([X11], [x11], [1.6])
+ XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2], [xfce_build_version()])
+ XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0], [xfce_build_version()])
+diff --git a/src/Helpers.cpp b/src/Helpers.cpp
+index 22a734b..d989950 100644
+--- a/src/Helpers.cpp
++++ b/src/Helpers.cpp
+@@ -161,7 +161,7 @@ namespace Help
+ 		void Timeout::start()
+ 		{
+ 			stop();
+-			mTimeoutId = g_timeout_add(mDuration, G_SOURCE_FUNC(+[](Timeout* me) {
++			mTimeoutId = g_timeout_add(mDuration, (GSourceFunc) (+[](Timeout* me) {
+ 				bool cont = me->mFunction();
+ 
+ 				if (!cont)
+-- 
+2.17.1
+


### PR DESCRIPTION
This PR adds a patch file which individuals (or CI's) may apply so the project builds fine for Ubuntu 18.04 (or similar) + XFCE 4.12.  
At same time, project code etc is not affected and stays "as is" for XFCE 4.14 & i.e. Ubuntu 20.04.   

* Closes issue #52
* Closes issue #41

```
git remote add gsantner https://github.com/gsantner/docklike-plugin.git && git fetch gsantner
git checkout feature-ubuntu1804-support && git reset --hard gsantner/feature-ubuntu1804-support
```

To apply run:  
 `git am < contrib/patches/0001-ubuntu-18.04-build-compatibility.patch`