### PR TITLE
startup: open windows are added to dock correctly

### DIFF
--- a/src/Wnck.cpp
+++ b/src/Wnck.cpp
@@ -98,8 +98,10 @@ namespace Wnck
 			GroupWindow* groupWindow = new GroupWindow(wnckWindow);
 			mGroupWindows.push(wnck_window_get_xid(wnckWindow), groupWindow);
 
+			groupWindow->leaveGroup();
 			groupWindow->updateState();
 		}
+
 		setActiveWindow();
 	}
 


### PR DESCRIPTION
I'm not 100% why this works, but it seems to solve the issue of some things being left off the dock when it is started.

I noticed that changing the workspace would update the groups correctly and the only thing that the callback does is call setVisibleGroups which uses the same loop, but calls leaveGroup.