### PR TITLE
Startup: load a default config for new plugin if it exists

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -31,9 +31,20 @@ namespace Settings
 	{
 
 		mPath = xfce_panel_plugin_save_location(Plugin::mXfPlugin, true);
-
 		mFile = g_key_file_new();
-		g_key_file_load_from_file(mFile, mPath.c_str(), G_KEY_FILE_NONE, NULL);
+
+		if (g_file_test(mPath.c_str(), G_FILE_TEST_IS_REGULAR))
+			g_key_file_load_from_file(mFile, mPath.c_str(), G_KEY_FILE_NONE, NULL);
+		
+		// Look for a default config file in XDG_CONFIG_DIRS/xfce4/panel/docklike.rc
+		else {
+			gchar* default_config = xfce_resource_lookup(XFCE_RESOURCE_CONFIG, "xfce4/panel/docklike.rc");
+
+			if (default_config, G_FILE_TEST_IS_REGULAR)
+				g_key_file_load_from_file(mFile, default_config, G_KEY_FILE_NONE, NULL);
+		
+			g_free(default_config);
+		}
 
 		indicatorOrientation.setup(g_key_file_get_integer(mFile, "user", "indicatorOrientation", NULL),
 			[](int indicatorOrientation) -> void {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -40,7 +40,7 @@ namespace Settings
 		else {
 			gchar* default_config = xfce_resource_lookup(XFCE_RESOURCE_CONFIG, "xfce4/panel/docklike.rc");
 
-			if (default_config, G_FILE_TEST_IS_REGULAR)
+			if (g_file_test(default_config, G_FILE_TEST_IS_REGULAR))
 				g_key_file_load_from_file(mFile, default_config, G_KEY_FILE_NONE, NULL);
 		
 			g_free(default_config);


### PR DESCRIPTION
Closes #87 

The plugin will now look for a XDG_CONFIG_DIRS/xfce4/panel/docklike.rc file if the plugin isn't configured to get default configuration.