### PR TITLE
resolve cpp template errors

### DIFF
--- a/src/Dock.hpp
+++ b/src/Dock.hpp
@@ -7,11 +7,7 @@
 #ifndef TASKBAR_HPP
 #define TASKBAR_HPP
 
-extern "C"
-{
-#include <libxfce4panel/libxfce4panel.h>
-#include <libxfce4ui/libxfce4ui.h>
-}
+
 
 #include <gtk/gtk.h>
 #include <libwnck/libwnck.h>

--- a/src/Dock.hpp
+++ b/src/Dock.hpp
@@ -7,8 +7,6 @@
 #ifndef TASKBAR_HPP
 #define TASKBAR_HPP
 
-
-
 #include <gtk/gtk.h>
 #include <libwnck/libwnck.h>
 
@@ -21,6 +19,7 @@
 #include "Settings.hpp"
 #include "Store.tpp"
 #include "Wnck.hpp"
+
 class Group;
 
 namespace Dock

--- a/src/SettingsDialog.hpp
+++ b/src/SettingsDialog.hpp
@@ -14,13 +14,6 @@
 #include "Helpers.hpp"
 #include "Settings.hpp"
 
-extern "C"
-{
-#include <libxfce4panel/libxfce4panel.h>
-#include <libxfce4ui/libxfce4ui.h>
-#include <libxfce4util/libxfce4util.h>
-}
-
 #include "Plugin.hpp"
 
 namespace SettingsDialog


### PR DESCRIPTION
Closes #95 
Closes #93
Closes #91 

Some software update hitting distros breaks the build process and outputs cpp template errors. I thought this was due to gcc 11 in Fedora 34, but I'm not so sure.