### PR TITLE
Add widget name (CSS id)

### DIFF
--- a/src/Dock.cpp
+++ b/src/Dock.cpp
@@ -23,6 +23,7 @@ namespace Dock
 		mBox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 		gtk_style_context_add_class(gtk_widget_get_style_context(GTK_WIDGET(mBox)), "stld");
 		gtk_widget_show(mBox);
+		gtk_widget_set_name(mBox, "docklike-taskbar");
 
 		// pinned groups
 		std::list<std::string> pinnedApps = Settings::pinnedAppList;


### PR DESCRIPTION
I added a name to mBox widget. This name can be used as an id in the gtk-3.0/gtk.css file.

![Screenshot](https://i.ibb.co/3Mw23mD/Screenshot-2022-03-01-16-25-04.png)